### PR TITLE
Quadtree Implementation

### DIFF
--- a/src/Math/Quaternion.h
+++ b/src/Math/Quaternion.h
@@ -54,6 +54,19 @@ public:
 		};
 	}
 
+    Vector2D RotateVectorUnit(Vector2D v, const Quaternion& q) {
+        if (IsClose(Quaternion(), Mathematics::EPSILON)) return v;
+
+        float s2 = q.W * 2.0f;
+        float dPUV = (q.X * v.X + q.Y * v.Y) * 2.0f;
+        float dPUU = q.W * q.W - (q.X * q.X + q.Y * q.Y + q.Z * q.Z);
+
+        return Vector2D{
+            X * dPUV + v.X * dPUU + (-(q.Z * v.Y)) * s2,
+            Y * dPUV + v.Y * dPUU + ((q.Z * v.X)) * s2
+        };
+    }
+
 	Vector2D UnrotateVector(Vector2D coordinate) {
 		if (IsClose(Quaternion(), Mathematics::EPSILON)) return coordinate;
 

--- a/src/Render/BoundingBox2D.h
+++ b/src/Render/BoundingBox2D.h
@@ -9,6 +9,7 @@ private:
 
 public:
     BoundingBox2D(){}
+    BoundingBox2D(Vector2D min, Vector2D max): min(min), max(max) {}
 
     void UpdateBounds(Vector2D current){
         min = min.Minimum(current);
@@ -23,10 +24,14 @@ public:
         return max;
     }
 
-    bool Overlaps(BoundingBox2D *bb){
+    bool Overlaps(BoundingBox2D* bb){
         bool xOverlap = bb->GetMinimum().X < max.X && bb->GetMaximum().X > min.X;
         bool yOverlap = bb->GetMinimum().Y < max.Y && bb->GetMaximum().Y > min.Y;
 
         return xOverlap && yOverlap;
+    }
+
+    bool Contains(const Vector2D& v) {
+        return min.X <= v.X && v.X <= max.X && min.Y <= v.Y && v.Y <= max.Y;
     }
 };

--- a/src/Render/Camera.h
+++ b/src/Render/Camera.h
@@ -27,8 +27,8 @@ private:
         RGBColor color;
         
         for (int t = 0; t < numTriangles; t++) {
-            if (triangles[t]->DidIntersect(pixelRay.X, pixelRay.Y, u, v, w)){
-                if(triangles[t]->averageDepth < zBuffer){
+            if (triangles[t]->averageDepth < zBuffer){
+                if(triangles[t]->DidIntersect(pixelRay.X, pixelRay.Y, u, v, w)){
                     uvw.X = u;
                     uvw.Y = v;
                     uvw.Z = w;
@@ -49,7 +49,7 @@ private:
                 uv = *triangles[triangle]->p1UV * uvw.X + *triangles[triangle]->p2UV * uvw.Y + *triangles[triangle]->p3UV * uvw.Z;
             }
             
-            color = triangles[triangle]->GetMaterial()->GetRGB(intersect, *triangles[triangle]->normal, Vector3D(uv.X, uv.Y, 0));
+            color = triangles[triangle]->GetMaterial()->GetRGB(intersect, *triangles[triangle]->normal, Vector3D(uv.X, uv.Y, 0.0f));
         }
         
         return color;

--- a/src/Render/Camera.h
+++ b/src/Render/Camera.h
@@ -76,11 +76,12 @@ public:
         int triangleCounter = 0;
         
         lookDirection = transform->GetRotation().Conjugate() * lookOffset;
+        Quaternion normLookDir = lookDirection.UnitQuaternion();
         rayDirection  = transform->GetRotation().Multiply(lookDirection);
 
         BoundingBox2D transformedBounds;
         for (unsigned int i = 0; i < pixelGroup->GetPixelCount(); ++i) {
-            Vector2D pixelRay = Vector2D(lookDirection.RotateVector(pixelGroup->GetPixel(i)->GetPosition() * transform->GetScale()));
+            Vector2D pixelRay = Vector2D(lookDirection.RotateVectorUnit(pixelGroup->GetPixel(i)->GetPosition() * transform->GetScale(), normLookDir));
             transformedBounds.UpdateBounds(pixelRay);
         }
 
@@ -99,7 +100,7 @@ public:
         tree.Rebuild();
 
         for (unsigned int i = 0; i < pixelGroup->GetPixelCount(); i++) {
-            Vector2D pixelRay = Vector2D(lookDirection.RotateVector(pixelGroup->GetPixel(i)->GetPosition() * transform->GetScale()));//scale pixel location prior to rotating and moving
+            Vector2D pixelRay = Vector2D(lookDirection.RotateVectorUnit(pixelGroup->GetPixel(i)->GetPosition() * transform->GetScale(), normLookDir));//scale pixel location prior to rotating and moving
             QuadTree::Node* leafNode =  tree.intersect(pixelRay);
             if (!leafNode) {
                 pixelGroup->GetPixel(i)->Color = RGBColor();

--- a/src/Render/Camera.h
+++ b/src/Render/Camera.h
@@ -73,16 +73,6 @@ public:
     }
 
     void Rasterize(Scene* scene) {
-        int numTriangles = 0;
-    
-        //for each object in the scene, get the triangles W
-        for(int i = 0; i < scene->GetObjectCount(); i++){
-            if(scene->GetObjects()[i]->IsEnabled()){
-                numTriangles += scene->GetObjects()[i]->GetTriangleGroup()->GetTriangleCount();
-            }
-        }
-        
-        Triangle2D** triangles = new Triangle2D*[numTriangles];
         int triangleCounter = 0;
         
         lookDirection = transform->GetRotation().Conjugate() * lookOffset;
@@ -101,12 +91,7 @@ public:
             if(scene->GetObjects()[i]->IsEnabled()){
                 //for each triangle in object, project onto 2d surface, but pass material
                 for (int j = 0; j < scene->GetObjects()[i]->GetTriangleGroup()->GetTriangleCount(); j++) {
-                    triangles[triangleCounter] = new Triangle2D(lookDirection, transform, &scene->GetObjects()[i]->GetTriangleGroup()->GetTriangles()[j], scene->GetObjects()[i]->GetMaterial());
-
-                    bool triangleInView = tree.insert(triangles[triangleCounter]);
-                    
-                    if(triangleInView) triangleCounter++;
-                    else delete triangles[triangleCounter];//out of view space remove from array
+                    tree.insert(Triangle2D(lookDirection, transform, &scene->GetObjects()[i]->GetTriangleGroup()->GetTriangles()[j], scene->GetObjects()[i]->GetMaterial()));
                 }
             }
         }
@@ -123,12 +108,6 @@ public:
 
             pixelGroup->GetPixel(i)->Color = CheckRasterPixel(leafNode->entities, leafNode->count, pixelRay);
         }
-
-        for (int i = 0; i < triangleCounter; i++){
-            delete triangles[i];
-        }
-        
-        delete[] triangles;
     }
     
 };

--- a/src/Render/QuadTree.h
+++ b/src/Render/QuadTree.h
@@ -1,0 +1,186 @@
+#pragma once
+#include "BoundingBox2D.h"
+#include "Triangle2D.h"
+
+
+class QuadTree {
+public:
+    class Node {
+    public:
+        Node() {
+            entities = new Triangle2D*[QuadTree::maxEntities]; //slightly inefficient since we always store the max number of pointers, could be optimized
+            for (int i = 0; i < QuadTree::maxEntities; ++i)
+                entities[i] = NULL;
+        };
+        ~Node() {
+            if(entities)
+                delete[] entities;
+
+            for (Node* childNode : childNodes) {
+                if (childNode)
+                    delete childNode;
+            }
+        }
+
+        void expand(unsigned int newCount) {
+            //printf("expanding node, new capacity: %d\n", newCount);
+            Triangle2D** tmp = entities;
+            entities = new Triangle2D*[newCount];
+            for (unsigned int i = 0; i < newCount; ++i) {
+                if (i < count)
+                    entities[i] = tmp[i];
+                else
+                    entities[i] = NULL;
+            }
+
+            delete[] tmp;
+            capacity = newCount;
+        }
+
+        //Note: node bboxes are implicit so we dont store them, therefore they need to be supplied externally whenever needed
+        bool insert(Triangle2D* triangle, BoundingBox2D& bbox, unsigned int depth = 0) {
+            if (!triangle->DidIntersect(bbox)) {
+                //printf("no intersection\n");
+                return false;
+            }
+           /* printf("inserting at depth: %d\n", depth);
+            printf("bbox: %.2f, %.2f, %.2f, %.2f\n", bbox.GetMinimum().X, bbox.GetMinimum().Y, bbox.GetMaximum().X, bbox.GetMaximum().Y);*/
+
+            if (count == capacity)
+                expand(2 * capacity);
+
+            entities[count] = triangle;
+            ++count;
+            //printf("inserted, count: %d\n", count);
+
+            return true;
+        }
+
+        void subdivide(BoundingBox2D& bbox, unsigned int depth = 0) {
+            //printf("subdividing node at depth %d\n", depth);
+            if (depth == QuadTree::maxDepth)
+                return;
+
+            Vector2D mid = (bbox.GetMinimum() + bbox.GetMaximum()) * 0.5f;
+
+            BoundingBox2D bboxes[] = { {bbox.GetMinimum(), mid}, {{mid.X, bbox.GetMinimum().Y}, {bbox.GetMaximum().X, mid.Y} },
+                                       {{bbox.GetMinimum().X, mid.Y}, {mid.X, bbox.GetMaximum().Y}}, {mid, bbox.GetMaximum()} };
+
+            for (int i = 0; i < 4; ++i) {
+                childNodes[i] = new Node();
+                for (int j = 0; j < count; ++j) {
+                    if (entities[j])
+                        childNodes[i]->insert(entities[j], bboxes[i], depth + 1);
+                }
+            }
+
+            delete[] entities;
+            entities = NULL;
+
+            //edge case: stop subdividing if we cant improve the average entity counts (eg due to suboptimal mesh topology)
+            float avgEntities = 0.0f;
+            for (int i = 0; i < 4; ++i)
+                avgEntities += 0.25f * (float)childNodes[i]->count;
+
+            bool canSubdiv = avgEntities < QuadTree::maxSubdivRatio * (float)count;
+
+            //printf("avg entities: %.2f, count: %d\n", avgEntities, count);
+
+            if (!canSubdiv) {
+                /*printf("cant improve subdiv ratio, stopping subdiv\n");
+                printf("avg entities: %.2f, count: %d\n", avgEntities, count);*/
+                count = 0;
+                return;
+            }
+
+            count = 0;
+
+            for (int i = 0; i < 4; ++i) {
+                if(childNodes[i]->count > QuadTree::maxEntities)
+                    childNodes[i]->subdivide(bboxes[i], depth + 1);
+            }
+        }
+
+        bool isLeaf() {
+            for (Node* childNode : childNodes) {
+                if (childNode)
+                    return false;
+            }
+
+            return true;
+        }
+
+        void PrintStats(int& totalCount) {
+            if (isLeaf()) {
+                printf("count: %d\n", count);
+                totalCount += count;
+            }
+            else {
+                for (Node* childNode : childNodes)
+                    childNode->PrintStats(totalCount);
+            }
+        }
+
+        uint16_t count = 0;
+        uint16_t capacity = QuadTree::maxEntities;
+        Node* childNodes[4] = {NULL, NULL, NULL, NULL};
+        Triangle2D** entities = NULL;
+    };
+
+public:
+    QuadTree(const BoundingBox2D& bounds): bbox(bounds){
+    }
+
+    bool insert(Triangle2D* triangle){
+        bool inserted = root.insert(triangle, bbox);
+        if (inserted)
+            ++count;
+        return inserted;
+    }
+
+    Node* intersect(const Vector2D& p) {
+        Node* currentNode = &root;
+        BoundingBox2D currentBbox = bbox;
+        while (1) {
+            if (currentNode->isLeaf())
+                return currentNode;
+
+            Vector2D mid = (currentBbox.GetMinimum() + currentBbox.GetMaximum()) * 0.5f;
+
+            BoundingBox2D bboxes[] = { {currentBbox.GetMinimum(), mid}, {{mid.X, currentBbox.GetMinimum().Y}, {currentBbox.GetMaximum().X, mid.Y} },
+                                       {{currentBbox.GetMinimum().X, mid.Y}, {mid.X, currentBbox.GetMaximum().Y}}, {mid, currentBbox.GetMaximum()} };
+
+            bool found = false;
+            for (int i = 0; i < 4; ++i) {
+                if (bboxes[i].Contains(p)) {
+                    currentNode = currentNode->childNodes[i];
+                    currentBbox = bboxes[i];
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+                return NULL;
+        }
+    }
+
+    void Rebuild() {
+        root.subdivide(bbox);
+    }
+
+    void PrintStats() {
+        int totalCount = 0;
+        printf("total inserts: %d\n", count);
+        printf("node stats: \n");
+        root.PrintStats(totalCount);
+        printf("total entities: %d \n", totalCount);
+    }
+
+private:
+    int count = 0;
+    Node root;
+    BoundingBox2D bbox;
+    static const int maxEntities = 16; //The maximum number of entities in a leaf node before subdividing
+    static const int maxDepth = 8;
+    static constexpr float maxSubdivRatio = 0.5f;
+};

--- a/src/Render/QuadTree.h
+++ b/src/Render/QuadTree.h
@@ -64,9 +64,6 @@ public:
             childNodes = new Node[4];
 
             for (int j = 0; j < count; ++j) {
-                if (!entities[j])
-                    continue;
-
                 int entityCount = 0;
                 for (int i = 0; i < 4; ++i) {
                     entityCount += childNodes[i].insert(entities[j], bboxes[i], depth + 1);
@@ -159,7 +156,7 @@ public:
             if (currentNode->isLeaf())
                 return currentNode;
 
-            Vector2D mid = (currentBbox.GetMinimum() + currentBbox.GetMaximum()) * 0.5f;
+            Vector2D mid = {(currentBbox.GetMinimum().X + currentBbox.GetMaximum().X) * 0.5f, (currentBbox.GetMinimum().Y + currentBbox.GetMaximum().Y) * 0.5f};
 
             BoundingBox2D bboxes[] = { {currentBbox.GetMinimum(), mid}, {{mid.X, currentBbox.GetMinimum().Y}, {currentBbox.GetMaximum().X, mid.Y} },
                                        {{currentBbox.GetMinimum().X, mid.Y}, {mid.X, currentBbox.GetMaximum().Y}}, {mid, currentBbox.GetMaximum()} };

--- a/src/Render/Scene.h
+++ b/src/Render/Scene.h
@@ -20,7 +20,6 @@ public:
 	}
 
 	~Scene(){
-        printf("destroying scene\n");
 		delete[] objects;
 	}
 

--- a/src/Render/Scene.h
+++ b/src/Render/Scene.h
@@ -20,6 +20,7 @@ public:
 	}
 
 	~Scene(){
+        printf("destroying scene\n");
 		delete[] objects;
 	}
 

--- a/src/Render/Triangle2D.h
+++ b/src/Render/Triangle2D.h
@@ -141,16 +141,20 @@ public:
     }
 
     bool DidIntersect(BoundingBox2D& bbox) {
-        Vector2D axes[] = { {1.0f, 0.0f}, {0.0f, 1.0f}, {-1.0f * (p2Y - p1Y), p2X - p1X},
-                            {-1.0f * (p3Y - p1Y), p3X - p1X}, {-1.0f * (p3Y - p2Y), (p3Y - p2Y)} }; // axes for SAT-based intersection testing
-
-        Vector2D c = (bbox.GetMinimum() + bbox.GetMaximum()) * 0.5f;
-        Vector2D e = (bbox.GetMaximum() - bbox.GetMinimum()) * 0.5f;
-
         //on x86 these are a lot faster than using fminf/fmaxf, TODO: verify performance on different platforms
         auto max = [](float a, float b) {return a > b ? a : b; };
         auto tmax = [](float a, float b, float c) {return a > b ? (a > c ? a : c) : (b > c ? b : c); };
         auto tmin = [](float a, float b, float c) {return a < b ? (a < c ? a : c) : (b < c ? b : c); };
+
+
+        if (!(bbox.GetMinimum().X < tmax(p1X, p2X, p3X) && bbox.GetMaximum().X > tmin(p1X, p2X, p3X))) { return false; }
+        if (!(bbox.GetMinimum().Y < tmax(p1Y, p2Y, p3Y) && bbox.GetMaximum().Y > tmin(p1Y, p2Y, p3Y))) { return false; }
+
+        Vector2D axes[] = { {-1.0f * (p2Y - p1Y), p2X - p1X},
+                            {-1.0f * (p3Y - p1Y), p3X - p1X}, {-1.0f * (p3Y - p2Y), (p3Y - p2Y)} }; // axes for SAT-based intersection testing
+
+        Vector2D c = (bbox.GetMinimum() + bbox.GetMaximum()) * 0.5f;
+        Vector2D e = (bbox.GetMaximum() - bbox.GetMinimum()) * 0.5f;
 
         for (const Vector2D& axis : axes) {
             //project vertices and bbox onto axis, relative to bbox center

--- a/src/Render/Triangle2D.h
+++ b/src/Render/Triangle2D.h
@@ -147,6 +147,11 @@ public:
         Vector2D c = (bbox.GetMinimum() + bbox.GetMaximum()) * 0.5f;
         Vector2D e = (bbox.GetMaximum() - bbox.GetMinimum()) * 0.5f;
 
+        //on x86 these are a lot faster than using fminf/fmaxf, TODO: verify performance on different platforms
+        auto max = [](float a, float b) {return a > b ? a : b; };
+        auto tmax = [](float a, float b, float c) {return a > b ? (a > c ? a : c) : (b > c ? b : c); };
+        auto tmin = [](float a, float b, float c) {return a < b ? (a < c ? a : c) : (b < c ? b : c); };
+
         for (const Vector2D& axis : axes) {
             //project vertices and bbox onto axis, relative to bbox center
             float p0 = axis.X * (p1X - c.X) + axis.Y * (p1Y - c.Y);
@@ -156,7 +161,10 @@ public:
             float r = e.X * fabsf(axis.X) + e.Y * fabsf(axis.Y);
 
             //if the projected ranges dont overlap then the axis is separating
-            if (fmaxf(-1.0f * fmaxf(p0, fmaxf(p1, p2)), fminf(p0, fminf(p1, p2))) > r)
+            /*if (fmaxf(-1.0f * fmaxf(p0, fmaxf(p1, p2)), fminf(p0, fminf(p1, p2))) > r)
+                return false;*/
+
+            if (max(-1.0f * tmax(p0, p1, p2), tmin(p0, p1, p2)) > r)
                 return false;
         }
 

--- a/src/Render/Triangle2D.h
+++ b/src/Render/Triangle2D.h
@@ -153,8 +153,8 @@ public:
         Vector2D axes[] = { {-1.0f * (p2Y - p1Y), p2X - p1X},
                             {-1.0f * (p3Y - p1Y), p3X - p1X}, {-1.0f * (p3Y - p2Y), (p3Y - p2Y)} }; // axes for SAT-based intersection testing
 
-        Vector2D c = (bbox.GetMinimum() + bbox.GetMaximum()) * 0.5f;
-        Vector2D e = (bbox.GetMaximum() - bbox.GetMinimum()) * 0.5f;
+        Vector2D c = {(bbox.GetMinimum().X + bbox.GetMaximum().X) * 0.5f, (bbox.GetMinimum().Y + bbox.GetMaximum().Y) * 0.5f };
+        Vector2D e = {(bbox.GetMaximum().X - bbox.GetMinimum().X) * 0.5f, (bbox.GetMaximum().Y - bbox.GetMinimum().Y) * 0.5f };
 
         for (const Vector2D& axis : axes) {
             //project vertices and bbox onto axis, relative to bbox center


### PR DESCRIPTION
This PR provides a preview of a proposed screenspace quadtree implementation for accelerating ray-triangle intersection testing. The rendering loop is modified to include the following steps:
- determine the screenspace bounds
- initialize a quadtree to the screen bounds
- insert each projected triangle into the tree
- for each pixel, determine the intersecting leaf node and test against the contained triangles

initial benchmarks show a significant performance increase for scenes with moderate to large triangle counts, some initial results can be found below.

| Scene | Platform | Render Time (original) | Render Time (quadtree) | Speedup|
|--------|-----------|-------------------------|----------------------------|----------|
|SpyroAnimation|x86|3.82ms|0.45ms| 8.49x|

Note that this implementation is not yet in a final stage, however the current state can already be used for testing and performance evaluation. For a final release the following TODOs will be addressed:
- reduce memory usage by avoiding unnecessary duplicate references to triangles
- adapt root node bounding box to intersection of screen bounds and triangle bounds
- evaluate performance on more platforms and scenes