### PR TITLE
Make ProgotenHub75 the default enabled project again

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,12 +4,12 @@
 #include "Examples\Protogen\ProtogenHardwareTest.h"
 #endif
 
-#include "Examples\Commissions\UnicornZhenjaAnimation.h"
-//#include "Examples\Protogen\ProtogenHUB75Project.h"
+//#include "Examples\Commissions\UnicornZhenjaAnimation.h"
+#include "Examples\Protogen\ProtogenHUB75Project.h"
 //#include "Examples\Protogen\ProtogenWS35Project.h"
 //#include "Examples\VerifyEngine.h"
 
-UnicornZhenjaAnimation project;
+ProtogenHUB75Project project;
 
 void setup() {
     Serial.begin(115200);


### PR DESCRIPTION
Restore ProtogenHub75 as the default enabled project so that newbies don't get stuck trying to run an animation that doesn't exist for them