### PR TITLE
Speed up offset effects when not used

### DIFF
--- a/lib/ProtoTracer/Scene/Screenspace/PhaseOffsetR.cpp
+++ b/lib/ProtoTracer/Scene/Screenspace/PhaseOffsetR.cpp
@@ -4,6 +4,8 @@
 PhaseOffsetR::PhaseOffsetR(uint8_t pixels) : pixels(pixels){}
 
 void PhaseOffsetR::ApplyEffect(IPixelGroup* pixelGroup) {
+    if (ratio <= 0.001f) return;
+
     uint16_t pixelCount = pixelGroup->GetPixelCount();
     RGBColor* pixelColors = pixelGroup->GetColors();
     RGBColor* colorBuffer = pixelGroup->GetColorBuffer();

--- a/lib/ProtoTracer/Scene/Screenspace/PhaseOffsetX.cpp
+++ b/lib/ProtoTracer/Scene/Screenspace/PhaseOffsetX.cpp
@@ -4,6 +4,8 @@
 PhaseOffsetX::PhaseOffsetX(uint8_t pixels) : pixels(pixels) {}
 
 void PhaseOffsetX::ApplyEffect(IPixelGroup* pixelGroup) {
+    if (ratio <= 0.001f) return;
+
     RGBColor* pixelColors = pixelGroup->GetColors();
     RGBColor* colorBuffer = pixelGroup->GetColorBuffer();
 

--- a/lib/ProtoTracer/Scene/Screenspace/PhaseOffsetY.cpp
+++ b/lib/ProtoTracer/Scene/Screenspace/PhaseOffsetY.cpp
@@ -4,6 +4,8 @@
 PhaseOffsetY::PhaseOffsetY(uint8_t pixels) : pixels(pixels) {}
 
 void PhaseOffsetY::ApplyEffect(IPixelGroup* pixelGroup) {
+    if (ratio <= 0.001f) return;
+
     RGBColor* pixelColors = pixelGroup->GetColors();
 
     for (uint16_t i = 0; i < pixelGroup->GetPixelCount(); i++) {


### PR DESCRIPTION
When using phase offset effects they consume a lot of resources from calculating the next pixel location when searching. I suspect there's a better way of calculating these by doing the analysis all at once and then picking points from a constructed list, turning the O(n^2) into a O(2n) complexity at the cost of a small amount of memory. Until then this shortcut bailout detects when using the effect would result in no changes to the pixels and returns early. Testing this on my protogen drastically sped up menu scrolling when using effects 1 [PhaseOffsetY], 2[PhaseOffsetX], and 3 [PhaseOffsetR] (Mostly 3). 

I didn't want to be changing the way the logic is handled in case someone wants to apply a persistent effect, but there might be value to check if the effect is a triggered effect (Short duration upon trigger, i.e. ratio > 0) and disabling all triggerable effects when not triggered. Doing this would allow all effects to not consume resources until used.