### PR TITLE
Increase optimization level

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ platform = teensy
 board = teensy40
 framework = arduino
 monitor_speed = 115200
+build_flags = -D TEENSY_OPT_FASTEST_LTO
 lib_deps = 
 	ProtoTracer
 	SPI
@@ -36,6 +37,7 @@ platform = teensy
 board = teensy41
 framework = arduino
 monitor_speed = 115200
+build_flags = -D TEENSY_OPT_FASTEST_LTO
 lib_deps = 
 	ProtoTracer
 	SPI


### PR DESCRIPTION
Increase the optimization from TEENSY_OPT_FASTER to TEENSY_OPT_FASTEST_LTO. Good for a 20fps increase, jumping up to the mid-80s.