### PR TITLE
Refactored platformio.ini, combined common lib_deps for readability

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,22 @@
 [common]
 extra_scripts = 
     scripts/RenameHex.py
+lib_deps = 
+	ProtoTracer
+	SPI
+	Wire
+	EEPROM
+	adafruit/Adafruit Unified Sensor@^1.1.4
+	paulstoffregen/OctoWS2811@^1.4
+	adafruit/Adafruit BNO055@^1.4.3
+	powerbroker2/SerialTransfer@^3.1.2
+	adafruit/Adafruit APDS9960 Library@^1.2.2
+	pixelmatix/SmartMatrix@^4.0.3
+	adafruit/Adafruit BusIO@^1.11.3
+	pedvide/Teensy_ADC@^9.1.0
+	adafruit/Adafruit SSD1306@^2.5.7
+	adafruit/Adafruit seesaw Library@^1.6.3
+	adafruit/Adafruit MMC56x3@^1.0.0
 
 [env:teensy40hub75]
 platform = teensy
@@ -20,22 +36,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_PROTOGEN_HUB75
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [env:teensy40ws35]
 platform = teensy
@@ -45,23 +46,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_PROTOGEN_WS35
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
-
+lib_deps = ${common.lib_deps}
 
 [env:teensy40beta]
 platform = teensy
@@ -71,22 +56,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_PROTOGEN_BETA
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [env:teensy40verifyrender]
 platform = teensy
@@ -96,22 +66,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_VERIFY_ENGINE
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [env:teensy40verifyhardware]
 platform = teensy
@@ -121,22 +76,8 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_VERIFY_HARDWARE
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
+
 	
 [env:teensy41hub75]
 platform = teensy
@@ -146,22 +87,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_PROTOGEN_HUB75
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [env:teensy41ws35]
 platform = teensy
@@ -171,22 +97,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_PROTOGEN_WS35
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [env:teensy41beta]
 platform = teensy
@@ -196,22 +107,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_PROTOGEN_BETA
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [env:teensy41verifyrender]
 platform = teensy
@@ -221,22 +117,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_VERIFY_ENGINE
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 
 [env:teensy41verifyhardware]
@@ -247,22 +128,7 @@ monitor_speed = 115200
 build_flags =
     -D PROJECT_VERIFY_HARDWARE
     -D TEENSY_OPT_FASTEST_LTO
-lib_deps = 
-	ProtoTracer
-	SPI
-	Wire
-	EEPROM
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	paulstoffregen/OctoWS2811@^1.4
-	adafruit/Adafruit BNO055@^1.4.3
-	powerbroker2/SerialTransfer@^3.1.2
-	adafruit/Adafruit APDS9960 Library@^1.2.2
-	pixelmatix/SmartMatrix@^4.0.3
-	adafruit/Adafruit BusIO@^1.11.3
-	pedvide/Teensy_ADC@^9.1.0
-	adafruit/Adafruit SSD1306@^2.5.7
-	adafruit/Adafruit seesaw Library@^1.6.3
-	adafruit/Adafruit MMC56x3@^1.0.0
+lib_deps = ${common.lib_deps}
 
 [platformio]
 description = This project is a 3D ray-tracing and animation engine for pixel matrices, designed to be used for drawing live animations on Protogen style characters from 3D object files (.OBJ).


### PR DESCRIPTION
There was a lot of reused lib_deps in platformio.ini, so I placed it in the common section to be reused, I tested to ensure things still built and indeed it is.
Not exactly a ground breaking fix but I thought it would be helpful for managing dependencies over the various platforms.